### PR TITLE
feat: Add Commenting System to Ideas

### DIFF
--- a/app/[locale]/api/ideas/[id]/comments/route.js
+++ b/app/[locale]/api/ideas/[id]/comments/route.js
@@ -1,0 +1,189 @@
+import { NextResponse } from 'next/server'
+
+/**
+ * In-memory store for demo purposes.
+ * Replace with a real database (e.g. Prisma, Supabase, MongoDB) in production.
+ */
+const store = new Map()
+
+const BLOCKED_PATTERNS = [
+  /\b(buy now|click here|free money|make money fast)\b/i,
+  /<script[\s\S]*?>[\s\S]*?<\/script>/i,
+  /javascript:/i,
+]
+
+function isMalicious(text) {
+  return BLOCKED_PATTERNS.some((re) => re.test(text))
+}
+
+// ── GET /api/ideas/[id]/comments ─────────────────────────────────────────────
+export async function GET(_req, { params }) {
+  const { id } = params
+  const comments = store.get(id) ?? []
+  return NextResponse.json({ comments })
+}
+
+// ── POST /api/ideas/[id]/comments ────────────────────────────────────────────
+export async function POST(req, { params }) {
+  const { id } = params
+
+  let body
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body.' }, { status: 400 })
+  }
+
+  const { content, authorId, authorName, authorAvatar, parentId } = body
+
+  if (!content || typeof content !== 'string' || !content.trim()) {
+    return NextResponse.json({ error: 'content is required.' }, { status: 400 })
+  }
+  if (content.length > 2000) {
+    return NextResponse.json({ error: 'content must be 2 000 characters or fewer.' }, { status: 400 })
+  }
+  if (isMalicious(content)) {
+    return NextResponse.json({ error: 'Comment contains disallowed content.' }, { status: 422 })
+  }
+  if (!authorId) {
+    return NextResponse.json({ error: 'authorId is required.' }, { status: 401 })
+  }
+
+  const newComment = {
+    id: crypto.randomUUID(),
+    ideaId: id,
+    parentId: parentId ?? null,
+    authorId,
+    authorName: authorName ?? 'Anonymous',
+    authorAvatar: authorAvatar ?? null,
+    content: content.trim(),
+    createdAt: new Date().toISOString(),
+    edited: false,
+    replies: [],
+  }
+
+  const comments = store.get(id) ?? []
+
+  if (parentId) {
+    // Append as nested reply
+    function addToTree(list) {
+      return list.map((c) => {
+        if (c.id === parentId) return { ...c, replies: [...c.replies, newComment] }
+        return { ...c, replies: addToTree(c.replies) }
+      })
+    }
+    store.set(id, addToTree(comments))
+  } else {
+    store.set(id, [...comments, newComment])
+  }
+
+  return NextResponse.json({ comment: newComment }, { status: 201 })
+}
+
+// ── PATCH /api/ideas/[id]/comments ───────────────────────────────────────────
+export async function PATCH(req, { params }) {
+  const { id } = params
+
+  let body
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body.' }, { status: 400 })
+  }
+
+  const { commentId, content, requesterId } = body
+
+  if (!commentId || !content || !requesterId) {
+    return NextResponse.json({ error: 'commentId, content and requesterId are required.' }, { status: 400 })
+  }
+  if (content.length > 2000) {
+    return NextResponse.json({ error: 'content must be 2 000 characters or fewer.' }, { status: 400 })
+  }
+  if (isMalicious(content)) {
+    return NextResponse.json({ error: 'Comment contains disallowed content.' }, { status: 422 })
+  }
+
+  const comments = store.get(id) ?? []
+  let found = false
+
+  function updateInTree(list) {
+    return list.map((c) => {
+      if (c.id === commentId) {
+        if (c.authorId !== requesterId) {
+          throw new Error('forbidden')
+        }
+        found = true
+        return { ...c, content: content.trim(), edited: true }
+      }
+      return { ...c, replies: updateInTree(c.replies) }
+    })
+  }
+
+  let updated
+  try {
+    updated = updateInTree(comments)
+  } catch (e) {
+    if (e.message === 'forbidden') {
+      return NextResponse.json({ error: 'You can only edit your own comments.' }, { status: 403 })
+    }
+    throw e
+  }
+
+  if (!found) {
+    return NextResponse.json({ error: 'Comment not found.' }, { status: 404 })
+  }
+
+  store.set(id, updated)
+  return NextResponse.json({ success: true })
+}
+
+// ── DELETE /api/ideas/[id]/comments ─────────────────────────────────────────
+export async function DELETE(req, { params }) {
+  const { id } = params
+
+  let body
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body.' }, { status: 400 })
+  }
+
+  const { commentId, requesterId } = body
+
+  if (!commentId || !requesterId) {
+    return NextResponse.json({ error: 'commentId and requesterId are required.' }, { status: 400 })
+  }
+
+  const comments = store.get(id) ?? []
+  let found = false
+
+  function removeFromTree(list) {
+    return list
+      .filter((c) => {
+        if (c.id === commentId) {
+          if (c.authorId !== requesterId) throw new Error('forbidden')
+          found = true
+          return false
+        }
+        return true
+      })
+      .map((c) => ({ ...c, replies: removeFromTree(c.replies) }))
+  }
+
+  let updated
+  try {
+    updated = removeFromTree(comments)
+  } catch (e) {
+    if (e.message === 'forbidden') {
+      return NextResponse.json({ error: 'You can only delete your own comments.' }, { status: 403 })
+    }
+    throw e
+  }
+
+  if (!found) {
+    return NextResponse.json({ error: 'Comment not found.' }, { status: 404 })
+  }
+
+  store.set(id, updated)
+  return NextResponse.json({ success: true })
+}

--- a/components/comments-section.jsx
+++ b/components/comments-section.jsx
@@ -1,0 +1,404 @@
+'use client'
+
+import * as React from 'react'
+import { MessageSquare, Send, Pencil, Trash2, Reply, ChevronDown, ChevronUp, AlertCircle } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+// ── Spam / content guard ──────────────────────────────────────────────────────
+const BLOCKED_PATTERNS = [
+  /\b(buy now|click here|free money|make money fast)\b/i,
+  /<script[\s\S]*?>[\s\S]*?<\/script>/i,
+  /javascript:/i,
+]
+
+function isMalicious(text) {
+  return BLOCKED_PATTERNS.some((re) => re.test(text))
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+function formatDate(iso) {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(iso))
+}
+
+function initials(name = '') {
+  return name
+    .split(' ')
+    .slice(0, 2)
+    .map((w) => w[0]?.toUpperCase() ?? '')
+    .join('')
+}
+
+// ── Single comment ────────────────────────────────────────────────────────────
+function CommentItem({ comment, currentUserId, onReply, onEdit, onDelete, depth = 0 }) {
+  const [isEditing, setIsEditing] = React.useState(false)
+  const [editContent, setEditContent] = React.useState(comment.content)
+  const [showReplies, setShowReplies] = React.useState(true)
+  const [isReplying, setIsReplying] = React.useState(false)
+  const [replyContent, setReplyContent] = React.useState('')
+  const [replyError, setReplyError] = React.useState('')
+  const [editError, setEditError] = React.useState('')
+
+  const isOwner = currentUserId && comment.authorId === currentUserId
+  const hasReplies = comment.replies && comment.replies.length > 0
+  const maxDepth = 3
+
+  function handleSaveEdit() {
+    const trimmed = editContent.trim()
+    if (!trimmed) return setEditError('Comment cannot be empty.')
+    if (trimmed.length > 2000) return setEditError('Comment must be 2 000 characters or fewer.')
+    if (isMalicious(trimmed)) return setEditError('Comment contains disallowed content.')
+    setEditError('')
+    onEdit(comment.id, trimmed)
+    setIsEditing(false)
+  }
+
+  function handleSubmitReply() {
+    const trimmed = replyContent.trim()
+    if (!trimmed) return setReplyError('Reply cannot be empty.')
+    if (trimmed.length > 2000) return setReplyError('Reply must be 2 000 characters or fewer.')
+    if (isMalicious(trimmed)) return setReplyError('Reply contains disallowed content.')
+    setReplyError('')
+    onReply(comment.id, trimmed)
+    setReplyContent('')
+    setIsReplying(false)
+  }
+
+  return (
+    <div
+      className={`flex gap-3 ${depth > 0 ? 'ml-8 pl-4 border-l-2 border-border' : ''}`}
+      role="article"
+      aria-label={`Comment by ${comment.authorName}`}
+    >
+      <Avatar className="h-8 w-8 shrink-0 mt-1">
+        <AvatarImage src={comment.authorAvatar} alt={comment.authorName} />
+        <AvatarFallback className="text-xs">{initials(comment.authorName)}</AvatarFallback>
+      </Avatar>
+
+      <div className="flex-1 min-w-0">
+        {/* Header */}
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="font-semibold text-sm">{comment.authorName}</span>
+          {comment.edited && (
+            <Badge variant="outline" className="text-xs py-0">
+              edited
+            </Badge>
+          )}
+          <span className="text-xs text-muted-foreground ml-auto">{formatDate(comment.createdAt)}</span>
+        </div>
+
+        {/* Body */}
+        {isEditing ? (
+          <div className="mt-2 space-y-2">
+            <Textarea
+              value={editContent}
+              onChange={(e) => setEditContent(e.target.value)}
+              rows={3}
+              maxLength={2000}
+              aria-label="Edit comment"
+            />
+            {editError && (
+              <p className="text-destructive text-xs flex items-center gap-1">
+                <AlertCircle className="h-3 w-3" /> {editError}
+              </p>
+            )}
+            <div className="flex gap-2">
+              <Button size="sm" onClick={handleSaveEdit}>
+                Save
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => {
+                  setIsEditing(false)
+                  setEditContent(comment.content)
+                  setEditError('')
+                }}
+              >
+                Cancel
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <p className="mt-1 text-sm whitespace-pre-wrap break-words">{comment.content}</p>
+        )}
+
+        {/* Actions */}
+        {!isEditing && (
+          <div className="flex items-center gap-1 mt-2">
+            {depth < maxDepth && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 px-2 text-xs"
+                onClick={() => setIsReplying((v) => !v)}
+                aria-label="Reply to comment"
+              >
+                <Reply className="h-3 w-3 mr-1" />
+                Reply
+              </Button>
+            )}
+            {isOwner && (
+              <>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 px-2 text-xs"
+                  onClick={() => setIsEditing(true)}
+                  aria-label="Edit comment"
+                >
+                  <Pencil className="h-3 w-3 mr-1" />
+                  Edit
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 px-2 text-xs text-destructive hover:text-destructive"
+                  onClick={() => onDelete(comment.id)}
+                  aria-label="Delete comment"
+                >
+                  <Trash2 className="h-3 w-3 mr-1" />
+                  Delete
+                </Button>
+              </>
+            )}
+          </div>
+        )}
+
+        {/* Reply form */}
+        {isReplying && (
+          <div className="mt-3 space-y-2">
+            <Textarea
+              placeholder="Write a reply…"
+              value={replyContent}
+              onChange={(e) => setReplyContent(e.target.value)}
+              rows={2}
+              maxLength={2000}
+              aria-label="Write a reply"
+            />
+            {replyError && (
+              <p className="text-destructive text-xs flex items-center gap-1">
+                <AlertCircle className="h-3 w-3" /> {replyError}
+              </p>
+            )}
+            <div className="flex gap-2">
+              <Button size="sm" onClick={handleSubmitReply}>
+                <Send className="h-3 w-3 mr-1" />
+                Post reply
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => {
+                  setIsReplying(false)
+                  setReplyContent('')
+                  setReplyError('')
+                }}
+              >
+                Cancel
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* Nested replies */}
+        {hasReplies && (
+          <div className="mt-3">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 px-2 text-xs mb-2"
+              onClick={() => setShowReplies((v) => !v)}
+              aria-expanded={showReplies}
+            >
+              {showReplies ? (
+                <>
+                  <ChevronUp className="h-3 w-3 mr-1" />
+                  Hide {comment.replies.length} {comment.replies.length === 1 ? 'reply' : 'replies'}
+                </>
+              ) : (
+                <>
+                  <ChevronDown className="h-3 w-3 mr-1" />
+                  Show {comment.replies.length} {comment.replies.length === 1 ? 'reply' : 'replies'}
+                </>
+              )}
+            </Button>
+            {showReplies && (
+              <div className="space-y-4">
+                {comment.replies.map((reply) => (
+                  <CommentItem
+                    key={reply.id}
+                    comment={reply}
+                    currentUserId={currentUserId}
+                    onReply={onReply}
+                    onEdit={onEdit}
+                    onDelete={onDelete}
+                    depth={depth + 1}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ── Main CommentsSection component ────────────────────────────────────────────
+
+/**
+ * CommentsSection — off-chain comment thread for idea pages.
+ *
+ * Props:
+ *   ideaId        {string}  The idea the comments belong to.
+ *   currentUser   {object}  { id, name, avatar } — null if not logged in.
+ *   comments      {array}   Flat or nested comment array (see shape below).
+ *   onAddComment  {fn}      (ideaId, content) => Promise<void>
+ *   onEditComment {fn}      (commentId, content) => Promise<void>
+ *   onDeleteComment {fn}    (commentId) => Promise<void>
+ *   onReplyComment  {fn}    (parentId, content) => Promise<void>
+ *   isLoading     {bool}
+ *
+ * Comment shape:
+ *   { id, ideaId, authorId, authorName, authorAvatar, content, createdAt, edited, replies: [] }
+ */
+export function CommentsSection({
+  ideaId,
+  currentUser,
+  comments = [],
+  onAddComment,
+  onEditComment,
+  onDeleteComment,
+  onReplyComment,
+  isLoading = false,
+}) {
+  const [newComment, setNewComment] = React.useState('')
+  const [submitError, setSubmitError] = React.useState('')
+  const [isSubmitting, setIsSubmitting] = React.useState(false)
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+    const trimmed = newComment.trim()
+    if (!trimmed) return setSubmitError('Comment cannot be empty.')
+    if (trimmed.length > 2000) return setSubmitError('Comment must be 2 000 characters or fewer.')
+    if (isMalicious(trimmed)) return setSubmitError('Your comment contains disallowed content.')
+    setSubmitError('')
+    setIsSubmitting(true)
+    try {
+      await onAddComment?.(ideaId, trimmed)
+      setNewComment('')
+    } catch {
+      setSubmitError('Failed to post comment. Please try again.')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  async function handleEdit(commentId, content) {
+    await onEditComment?.(commentId, content)
+  }
+
+  async function handleDelete(commentId) {
+    await onDeleteComment?.(commentId)
+  }
+
+  async function handleReply(parentId, content) {
+    await onReplyComment?.(parentId, content)
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base flex items-center gap-2">
+          <MessageSquare className="h-4 w-4" aria-hidden="true" />
+          Comments
+          {comments.length > 0 && (
+            <Badge variant="secondary" className="ml-1">
+              {comments.length}
+            </Badge>
+          )}
+        </CardTitle>
+      </CardHeader>
+
+      <CardContent className="space-y-6">
+        {/* New comment form */}
+        {currentUser ? (
+          <form onSubmit={handleSubmit} className="flex gap-3" noValidate>
+            <Avatar className="h-8 w-8 shrink-0 mt-1">
+              <AvatarImage src={currentUser.avatar} alt={currentUser.name} />
+              <AvatarFallback className="text-xs">{initials(currentUser.name)}</AvatarFallback>
+            </Avatar>
+            <div className="flex-1 space-y-2">
+              <Textarea
+                placeholder="Share your thoughts on this idea…"
+                value={newComment}
+                onChange={(e) => setNewComment(e.target.value)}
+                rows={3}
+                maxLength={2000}
+                aria-label="New comment"
+                disabled={isSubmitting}
+              />
+              {submitError && (
+                <p role="alert" className="text-destructive text-xs flex items-center gap-1">
+                  <AlertCircle className="h-3 w-3" />
+                  {submitError}
+                </p>
+              )}
+              <div className="flex items-center justify-between">
+                <span className="text-xs text-muted-foreground">{newComment.length} / 2000</span>
+                <Button type="submit" size="sm" disabled={isSubmitting || !newComment.trim()}>
+                  <Send className="h-3 w-3 mr-1" />
+                  {isSubmitting ? 'Posting…' : 'Post comment'}
+                </Button>
+              </div>
+            </div>
+          </form>
+        ) : (
+          <p className="text-sm text-muted-foreground text-center py-2">
+            Sign in to join the discussion.
+          </p>
+        )}
+
+        {/* Comment thread */}
+        {isLoading ? (
+          <div className="space-y-4">
+            {[...Array(3)].map((_, i) => (
+              <div key={i} className="flex gap-3 animate-pulse">
+                <div className="h-8 w-8 rounded-full bg-muted shrink-0" />
+                <div className="flex-1 space-y-2">
+                  <div className="h-3 w-24 rounded bg-muted" />
+                  <div className="h-10 rounded bg-muted" />
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : comments.length === 0 ? (
+          <p className="text-sm text-muted-foreground text-center py-6">
+            No comments yet. Be the first to share your thoughts!
+          </p>
+        ) : (
+          <div className="space-y-6" role="list" aria-label="Comments">
+            {comments.map((comment) => (
+              <div key={comment.id} role="listitem">
+                <CommentItem
+                  comment={comment}
+                  currentUserId={currentUser?.id}
+                  onReply={handleReply}
+                  onEdit={handleEdit}
+                  onDelete={handleDelete}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/hooks/use-comments.jsx
+++ b/hooks/use-comments.jsx
@@ -1,0 +1,102 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+
+/**
+ * useComments — manages off-chain comment state for an idea page.
+ *
+ * In production wire the fetch/mutate calls to your API routes.
+ * Currently uses localStorage for demo purposes.
+ */
+export function useComments(ideaId) {
+  const [comments, setComments] = useState([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  // ── Load ────────────────────────────────────────────────────────────────────
+  useEffect(() => {
+    if (!ideaId) return
+    setIsLoading(true)
+    setError(null)
+
+    // Replace with: fetch(`/api/ideas/${ideaId}/comments`)
+    try {
+      const stored = typeof window !== 'undefined'
+        ? JSON.parse(localStorage.getItem(`comments:${ideaId}`) || '[]')
+        : []
+      setComments(stored)
+    } catch {
+      setError('Failed to load comments.')
+    } finally {
+      setIsLoading(false)
+    }
+  }, [ideaId])
+
+  const persist = useCallback((updated) => {
+    setComments(updated)
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(`comments:${ideaId}`, JSON.stringify(updated))
+    }
+  }, [ideaId])
+
+  // ── Add ─────────────────────────────────────────────────────────────────────
+  const addComment = useCallback(async (id, content, currentUser) => {
+    const newComment = {
+      id: crypto.randomUUID(),
+      ideaId: id,
+      authorId: currentUser.id,
+      authorName: currentUser.name,
+      authorAvatar: currentUser.avatar ?? null,
+      content,
+      createdAt: new Date().toISOString(),
+      edited: false,
+      replies: [],
+    }
+    persist([...comments, newComment])
+  }, [comments, persist])
+
+  // ── Edit ────────────────────────────────────────────────────────────────────
+  const editComment = useCallback(async (commentId, content) => {
+    function updateInTree(list) {
+      return list.map((c) => {
+        if (c.id === commentId) return { ...c, content, edited: true }
+        return { ...c, replies: updateInTree(c.replies ?? []) }
+      })
+    }
+    persist(updateInTree(comments))
+  }, [comments, persist])
+
+  // ── Delete ──────────────────────────────────────────────────────────────────
+  const deleteComment = useCallback(async (commentId) => {
+    function removeFromTree(list) {
+      return list
+        .filter((c) => c.id !== commentId)
+        .map((c) => ({ ...c, replies: removeFromTree(c.replies ?? []) }))
+    }
+    persist(removeFromTree(comments))
+  }, [comments, persist])
+
+  // ── Reply ───────────────────────────────────────────────────────────────────
+  const replyComment = useCallback(async (parentId, content, currentUser) => {
+    const newReply = {
+      id: crypto.randomUUID(),
+      ideaId,
+      authorId: currentUser.id,
+      authorName: currentUser.name,
+      authorAvatar: currentUser.avatar ?? null,
+      content,
+      createdAt: new Date().toISOString(),
+      edited: false,
+      replies: [],
+    }
+    function addToTree(list) {
+      return list.map((c) => {
+        if (c.id === parentId) return { ...c, replies: [...(c.replies ?? []), newReply] }
+        return { ...c, replies: addToTree(c.replies ?? []) }
+      })
+    }
+    persist(addToTree(comments))
+  }, [comments, ideaId, persist])
+
+  return { comments, isLoading, error, addComment, editComment, deleteComment, replyComment }
+}


### PR DESCRIPTION
## Summary

Implements a full off-chain commenting system for idea pages, fulfilling all acceptance criteria in the issue.

## What's Changed

### components/comments-section.jsx
- Comment submission form with 2000-character limit and spam/XSS guard
- Threaded comment display with author avatar, name and timestamp
- Inline edit and delete controls (owner-only)
- Threaded replies up to 3 levels deep with collapse/expand toggle
- Loading skeleton and empty-state messaging
- Full accessibility (role, aria-label, aria-expanded)

### hooks/use-comments.jsx
- useComments(ideaId) hook for off-chain comment state management
- Exposes addComment, editComment, deleteComment, replyComment
- Backed by localStorage; swap for real API calls in production

### app/[locale]/api/ideas/[id]/comments/route.js
- GET returns all comments for an idea
- POST creates a new comment or threaded reply; validates content and rejects spam/malicious content (HTTP 422)
- PATCH edits a comment; enforces author-only access (HTTP 403 for others)
- DELETE deletes a comment; enforces author-only access (HTTP 403 for others)

closes #90